### PR TITLE
complete test for llm_providers.py

### DIFF
--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -103,6 +103,7 @@ def test_http_request(mock_post, mock_get, method, return_value, side_effect,
 @patch("commizard.llm_providers.list_locals")
 def test_init_model_list(mock_list, monkeypatch):
     monkeypatch.setattr(llm, "available_models", None)
+    llm.init_model_list()
     assert mock_list.assert_called_once()
 
 

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -108,13 +108,9 @@ def test_init_model_list(mock_list, monkeypatch):
 
 @patch("commizard.llm_providers.http_request")
 def test_unload_model(mock_http_request, monkeypatch):
-    # Patch the global variable
     monkeypatch.setattr(llm, "selected_model", "mymodel")
-
-    # Act
     llm.unload_model()
-
-    # Assert http_request called once with expected args
+    # http_request called once with expected args
     mock_http_request.assert_called_once_with(
         "POST", "http://localhost:11434/api/generate", json={"model": "mymodel",
                                                              "keep_alive": 0})

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -110,7 +110,7 @@ def test_init_model_list(mock_list, monkeypatch):
         ({"done_reason": "other"}, False),
     ],
 )
-@patch("commizard.output.print_success")
+@patch("commizard.llm_providers.output.print_success")
 @patch("commizard.llm_providers.load_model")
 def test_select_model(mock_load_model, mock_print_success, monkeypatch,
                       load_return, expect_success):
@@ -141,7 +141,7 @@ def test_select_model(mock_load_model, mock_print_success, monkeypatch,
         (False, {"models": []}, [], False),
     ],
 )
-@patch("commizard.output.print_error")
+@patch("commizard.llm_providers.output.print_error")
 @patch("commizard.llm_providers.http_request")
 def test_list_locals(mock_http_request, mock_print_error,
                      is_error, response, expected_result, expect_error):
@@ -195,7 +195,6 @@ def test_load_model(mock_http_request, mock_print_error, monkeypatch, is_error,
 def test_unload_model(mock_http_request, monkeypatch):
     monkeypatch.setattr(llm, "selected_model", "mymodel")
     llm.unload_model()
-    # http_request called once with expected args
     mock_http_request.assert_called_once_with(
         "POST", "http://localhost:11434/api/generate", json={"model": "mymodel",
                                                              "keep_alive": 0})
@@ -210,15 +209,15 @@ def test_unload_model(mock_http_request, monkeypatch):
          True),
     ],
 )
-@patch("commizard.output.print_generated")
-@patch("commizard.output.wrap_text")
+@patch("commizard.llm_providers.output.print_generated")
+@patch("commizard.llm_providers.output.wrap_text")
 @patch("commizard.llm_providers.http_request")
-@patch("commizard.git_utils.get_diff")
-@patch("commizard.output.print_warning")
+@patch("commizard.llm_providers.git_utils.get_diff")
+@patch("commizard.llm_providers.output.print_warning")
 def test_generate(mock_print_warning, mock_get_diff, mock_http_request,
                   mock_wrap_text, mock_print_generated, monkeypatch,
                   diff, expected_gen_message, expect_warning, expect_http):
-    monkeypatch.setattr(llm, "selected_model", "mymodel")
+    monkeypatch.setattr(llm, "selected_model", "my_model")
     monkeypatch.setattr(llm, "gen_message", None)
 
     mock_get_diff.return_value = diff
@@ -226,7 +225,7 @@ def test_generate(mock_print_warning, mock_get_diff, mock_http_request,
     # Configure http_request / wrap_text if HTTP is expected
     if expect_http:
         fake_response = Mock()
-        fake_response.response = {"response": " the sky is black, I'm retard\n"}
+        fake_response.response = {"response": " the sky is black, I'm dumb\n"}
         mock_http_request.return_value = fake_response
 
     llm.generate()
@@ -238,11 +237,10 @@ def test_generate(mock_print_warning, mock_get_diff, mock_http_request,
     else:
         mock_print_warning.assert_not_called()
 
-    # Assert HTTP request
     if expect_http:
         mock_http_request.assert_called_once_with(
             "POST", "http://localhost:11434/api/generate",
-            json={"model": "mymodel",
+            json={"model": "my_model",
                   "prompt": llm.generation_prompt + diff,
                   "stream": False
                   }

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -109,12 +109,12 @@ def test_init_model_list(mock_list, monkeypatch):
 @pytest.mark.parametrize(
     "is_error, response, expected_result, expect_error",
     [
-        # Case 1: http_request returns error
+        # http_request returns error
         (True, None, [], True),
-        # Case 2: http_request succeeds with models
+        # http_request succeeds with models
         (False, {"models": [{"name": "model1"}, {"name": "model2"}]},
          ["model1", "model2"], False),
-        # Case 3: http_request succeeds but no models
+        # http_request succeeds but no models
         (False, {"models": []}, [], False),
     ],
 )

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -6,6 +6,10 @@ import requests
 from commizard import llm_providers as llm
 
 
+# TODO: implement test for: init_model_list, list_locals, select_model,
+#       load_model
+
+
 @pytest.mark.parametrize(
     "response, return_code, expected_is_error, expected_err_message",
     [

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -6,7 +6,7 @@ import requests
 from commizard import llm_providers as llm
 
 
-# TODO: implement test for: select_model, load_model
+# TODO: implement test for: load_model
 
 
 @pytest.mark.parametrize(

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -6,8 +6,7 @@ import requests
 from commizard import llm_providers as llm
 
 
-# TODO: implement test for: list_locals, select_model,
-#       load_model
+# TODO: implement test for: select_model, load_model
 
 
 @pytest.mark.parametrize(

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -22,8 +22,8 @@ from commizard import llm_providers as llm
         ("", -4, True, "the request timed out"),
     ],
 )
-def test_http_response(response, return_code, expected_is_error,
-                       expected_err_message):
+def test_HttpResponse(response, return_code, expected_is_error,
+                      expected_err_message):
     http_resp = llm.HttpResponse(response, return_code)
 
     assert http_resp.response == response

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -96,6 +96,21 @@ def test_http_request(mock_post, mock_get, method, return_value, side_effect,
         assert result.return_code == expected_code
 
 
+@patch("commizard.llm_providers.http_request")
+def test_unload_model(mock_http_request, monkeypatch):
+    # Patch the global variable
+    monkeypatch.setattr(llm, "selected_model", "mymodel")
+
+    # Act
+    llm.unload_model()
+
+    # Assert http_request called once with expected args
+    mock_http_request.assert_called_once_with(
+        "POST", "http://localhost:11434/api/generate", json={"model": "mymodel",
+                                                             "keep_alive": 0})
+    assert llm.selected_model is None
+
+
 @pytest.mark.parametrize(
     "select_str, load_val, should_print",
     [

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -107,6 +107,32 @@ def test_init_model_list(mock_list, monkeypatch):
 
 
 @pytest.mark.parametrize(
+    "load_return, expect_success",
+    [
+        ({"done_reason": "load"}, True),
+        ({"done_reason": "other"}, False),
+    ],
+)
+@patch("commizard.output.print_success")
+@patch("commizard.llm_providers.load_model")
+def test_select_model(mock_load_model, mock_print_success, monkeypatch,
+                      load_return, expect_success):
+    monkeypatch.setattr(llm, "selected_model", None)
+    mock_load_model.return_value = load_return
+
+    llm.select_model("cool_model")
+
+    assert llm.selected_model == "cool_model"
+
+    mock_load_model.assert_called_once_with("cool_model")
+
+    if expect_success:
+        mock_print_success.assert_called_once_with("cool_model loaded.")
+    else:
+        mock_print_success.assert_not_called()
+
+
+@pytest.mark.parametrize(
     "is_error, response, expected_result, expect_error",
     [
         # http_request returns error

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -33,7 +33,8 @@ def test_http_response(response, return_code, expected_is_error,
 
 
 @pytest.mark.parametrize(
-    "method, return_value, side_effect, expected_response, expected_code, expected_exception",
+    "method, return_value, side_effect, expected_response, expected_code,"
+    "expected_exception",
     [
         # --- Success cases ---
         ("GET", {"json": {"key": "val"}, "status": 200}, None, {"key": "val"},

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -103,7 +103,7 @@ def test_http_request(mock_post, mock_get, method, return_value, side_effect,
 def test_init_model_list(mock_list, monkeypatch):
     monkeypatch.setattr(llm, "available_models", None)
     llm.init_model_list()
-    assert mock_list.assert_called_once()
+    mock_list.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -132,9 +132,11 @@ def test_select_model(mock_load_model, mock_print_success, monkeypatch,
     [
         # http_request returns error
         (True, None, [], True),
+
         # http_request succeeds with models
         (False, {"models": [{"name": "model1"}, {"name": "model2"}]},
          ["model1", "model2"], False),
+
         # http_request succeeds but no models
         (False, {"models": []}, [], False),
     ],

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -71,6 +71,7 @@ def test_http_request(mock_post, mock_get, method, return_value, side_effect,
     elif method.upper() == "POST":
         mock_target = mock_post
 
+    # setup mock_target based on the return_value dict
     if mock_target:
         if side_effect:
             mock_target.side_effect = side_effect

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -1,11 +1,7 @@
-# It's a bad idea to add most of the tests for this module at this stage. We
-# should first refactor the requests to be inside a wrapper. If we write the
-# tests first, We'll just add work when we have to inevitably refactor it as we
-# scale.
-# One other thing: we'll use monkeypatching for global vars.
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import pytest
+import requests
 
 from commizard import llm_providers as llm
 
@@ -34,6 +30,71 @@ def test_http_response(response, return_code, expected_is_error,
     assert http_resp.return_code == return_code
     assert http_resp.is_error() == expected_is_error
     assert http_resp.err_message() == expected_err_message
+
+
+@pytest.mark.parametrize(
+    "method, url, target, side_effect, json_value, text_value, status_code,"
+    "expected_response, expected_code",
+    [
+        # GET with JSON
+        ("GET", "http://test.com", "requests.get", None, {"key": "val"}, None,
+         200, {"key": "val"}, 200),
+
+        # GET with text (json raises JSONDecodeError)
+        ("GET", "http://test.com", "requests.get", None,
+         requests.exceptions.JSONDecodeError("err", "doc", 0),
+         "plain text", 200, "plain text", 200),
+
+        # POST with JSON
+        ("POST", "http://test.com", "requests.post", None, {"ok": True}, None,
+         201, {"ok": True}, 201),
+
+        # ConnectionError
+        ("GET", "http://test.com", "requests.get", requests.ConnectionError,
+         None, None, None, None, -1),
+
+        # HTTPError
+        ("GET", "http://test.com", "requests.get", requests.HTTPError, None,
+         None, None, None, -2),
+
+        # TooManyRedirects
+        ("GET", "http://test.com", "requests.get", requests.TooManyRedirects,
+         None, None, None, None, -3),
+
+        # Timeout
+        ("GET", "http://test.com", "requests.get", requests.Timeout, None, None,
+         None, None, -4),
+
+        # Generic RequestException
+        ("GET", "http://test.com", "requests.get", requests.RequestException,
+         None, None, None, None, -5),
+    ],
+)
+@patch("requests.get")
+@patch("requests.post")
+def test_http_request(mock_post, mock_get, method, url, target, side_effect,
+                      json_value, text_value, status_code, expected_response,
+                      expected_code):
+    # pick the right mock to configure
+    mock_target = mock_get if target.endswith("get") else mock_post
+
+    if side_effect:
+        mock_target.side_effect = side_effect
+    else:
+        mock_resp = Mock()
+        mock_resp.status_code = status_code
+        if isinstance(json_value, Exception):
+            mock_resp.json.side_effect = json_value
+        else:
+            mock_resp.json.return_value = json_value
+        mock_resp.text = text_value
+        mock_target.return_value = mock_resp
+
+    result = llm.http_request(method, url)
+
+    assert isinstance(result, llm.HttpResponse)
+    assert result.return_code == expected_code
+    assert result.response == expected_response
 
 
 @pytest.mark.parametrize(

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -6,7 +6,7 @@ import requests
 from commizard import llm_providers as llm
 
 
-# TODO: implement test for: init_model_list, list_locals, select_model,
+# TODO: implement test for: list_locals, select_model,
 #       load_model
 
 
@@ -98,6 +98,12 @@ def test_http_request(mock_post, mock_get, method, return_value, side_effect,
         assert isinstance(result, llm.HttpResponse)
         assert result.response == expected_response
         assert result.return_code == expected_code
+
+
+@patch("commizard.llm_providers.list_locals")
+def test_init_model_list(mock_list, monkeypatch):
+    monkeypatch.setattr(llm, "available_models", None)
+    assert mock_list.assert_called_once()
 
 
 @patch("commizard.llm_providers.http_request")

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -39,11 +39,9 @@ def test_HttpResponse(response, return_code, expected_is_error,
         # --- Success cases ---
         ("GET", {"json": {"key": "val"}, "status": 200}, None, {"key": "val"},
          200, None),
-
         ("GET", {"json": requests.exceptions.JSONDecodeError("err", "doc", 0),
                  "text": "plain text", "status": 200}, None, "plain text", 200,
          None),
-
         ("POST", {"json": {"ok": True}, "status": 201}, None, {"ok": True}, 201,
          None),
         ("GET", {"json": {"key": "val"}, "status": 503}, None, {"key": "val"},

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -6,7 +6,34 @@
 from unittest.mock import patch
 
 import pytest
+
 from commizard import llm_providers as llm
+
+
+@pytest.mark.parametrize(
+    "response, return_code, expected_is_error, expected_err_message",
+    [
+        # Non-error responses
+        ("ok", 200, False, ""),
+        ("created", 201, False, ""),
+        ("empty", 0, False, ""),
+        ({"reason": "not found"}, 404, False, ""),
+
+        # Error cases
+        ("404", -1, True, "can't connect to the server"),
+        ("success", -2, True, "HTTP error occurred"),
+        ({1: "found"}, -3, True, "too many redirects"),
+        ("", -4, True, "the request timed out"),
+    ],
+)
+def test_http_response(response, return_code, expected_is_error,
+                       expected_err_message):
+    http_resp = llm.HttpResponse(response, return_code)
+
+    assert http_resp.response == response
+    assert http_resp.return_code == return_code
+    assert http_resp.is_error() == expected_is_error
+    assert http_resp.err_message() == expected_err_message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Before this, the test_llm_providers.py was just a placeholder with only 1 test: test_select_model. Now that all the code has been refactored, we finish this file's testing