### PR TITLE
add commit functionality

### DIFF
--- a/src/commizard/commands.py
+++ b/src/commizard/commands.py
@@ -5,7 +5,7 @@ from . import output
 from .git_utils import commit
 
 
-def handle_commit_req(opts: list) -> None:
+def handle_commit_req(opts: list[str]) -> None:
     """
     commits the generated prompt. prints an error message if commiting fails
     """
@@ -20,7 +20,7 @@ def handle_commit_req(opts: list) -> None:
 
 
 # TODO: implement
-def print_help(opts: list) -> None:
+def print_help(opts: list[str]) -> None:
     """
     prints a list of all commands and a brief description
 
@@ -33,7 +33,7 @@ def print_help(opts: list) -> None:
     pass
 
 
-def copy_command(opts: list) -> None:
+def copy_command(opts: list[str]) -> None:
     """
     copies the generated prompt to clipboard according to options passed.
 
@@ -69,7 +69,7 @@ def start_model(opts: list[str]) -> None:
     llm_providers.select_model(model_name)
 
 
-def print_available_models(opts: list) -> None:
+def print_available_models(opts: list[str]) -> None:
     """
     prints the available models according to options passed.
     """
@@ -78,7 +78,7 @@ def print_available_models(opts: list) -> None:
         print(model)
 
 
-def generate_message(opts: list) -> None:
+def generate_message(opts: list[str]) -> None:
     """
     generate and print a commit message
     """

--- a/src/commizard/commands.py
+++ b/src/commizard/commands.py
@@ -9,7 +9,7 @@ def handle_commit_req(opts: list) -> None:
     """
     commits the generated prompt. prints an error message if commiting fails
     """
-    if llm_providers.gen_message == None or llm_providers.gen_message == "":
+    if llm_providers.gen_message is None or llm_providers.gen_message == "":
         output.print_warning("No commit message detected. Skipping.")
         return
     out, msg = commit(llm_providers.gen_message)

--- a/src/commizard/commands.py
+++ b/src/commizard/commands.py
@@ -1,45 +1,22 @@
-import subprocess
-
 import pyperclip
 
 from . import llm_providers
 from . import output
+from .git_utils import commit
 
 
-# TODO: see issue #4
-def handle_commit_req(opts: list) -> int:
+def handle_commit_req(opts: list) -> None:
     """
-    commits the generated prompt according to options:
-        If none specified, commits both the Title and the Body
-        If passed body or title like : commit body, or: commit title,
-        only commits the parts specified.
-
-    Args:
-        opts: a list of options following the commit command passed to the cli.
-
-    Returns:
-        a status code: 0 for success, 1 for failure, 2 for incorrect
-        prompt input.
+    commits the generated prompt. prints an error message if commiting fails
     """
-    if opts == []:
-        out = subprocess.run(
-            ["git", "commit", "-a", "-m", gen_head, "-m", gen_body],
-            capture_output=True)
-    elif opts[0] in ("-h", "--help"):
-        # TODO: Do something for the helps. This will get super bad super quick
-        print("""options:\n
-        The commit command will commit both the title and the body by default.\n
-        head | title: Just commit the head, ignore the body.\n
-        body: Commit the body without the head""")
-    elif opts[0] in ("head", "title"):
-        out = subprocess.run(
-            ["git", "commit", "-a", "-m", gen_head], capture_output=True)
-    elif opts[0] == "body":
-        out = subprocess.run(
-            ["git", "commit", "-a", "-m", gen_body], capture_output=True)
+    if llm_providers.gen_message == None or llm_providers.gen_message == "":
+        output.print_warning("No commit message detected. Skipping.")
+        return
+    out, msg = commit(llm_providers.gen_message)
+    if out == 0:
+        output.print_success(msg)
     else:
-        output.print_error(f"Error: {opts[0]} is not a valid commit command.")
-        return 2
+        output.print_warning(msg)
 
 
 # TODO: implement

--- a/src/commizard/git_utils.py
+++ b/src/commizard/git_utils.py
@@ -46,11 +46,12 @@ def get_diff() -> str:
         return out.stdout.strip()
 
 
-def commit(msg: str) -> int:
+def commit(msg: str) -> tuple[int, str]:
     """
     commit with msg as the commit text.
     Returns:
-        the return value from running the commit command
+        the return value from running the commit command, stdout, and stderr
     """
     out = run_git_command(["commit", "-a", "-m", msg])
-    return out.returncode
+    ret = out.stdout.strip() if out.stdout.strip() != "" else out.stderr.strip()
+    return out.returncode, ret

--- a/src/commizard/git_utils.py
+++ b/src/commizard/git_utils.py
@@ -44,3 +44,13 @@ def get_diff() -> str:
 
     if out.returncode == 0:
         return out.stdout.strip()
+
+
+def commit(msg: str) -> int:
+    """
+    commit with msg as the commit text.
+    Returns:
+        the return value from running the commit command
+    """
+    out = run_git_command(["commit", "-a", "-m", msg])
+    return out.returncode

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -123,3 +123,26 @@ def test_get_diff(mock_run, mock_val, expected):
         mock_run.assert_any_call(["--no-pager", "diff", "--no-color"])
 
     assert res == expected
+
+
+@pytest.mark.parametrize(
+    "stdout, stderr, expected_ret",
+    [
+        ("Commit successful\n", "", "Commit successful"),
+        ("   \n", "Some error\n", "Some error"),
+        ("   \n", "   \n", ""),
+    ],
+)
+@patch("commizard.git_utils.run_git_command")
+def test_commit(mock_run_git_command, stdout, stderr, expected_ret):
+    # arrange: directly configure the mock return value
+    mock_run_git_command.return_value.stdout = stdout
+    mock_run_git_command.return_value.stderr = stderr
+    mock_run_git_command.return_value.returncode = 42
+
+    code, output = git_utils.commit("test message")
+
+    mock_run_git_command.assert_called_once_with(
+        ["commit", "-a", "-m", "test message"])
+    assert code == 42
+    assert output == expected_ret


### PR DESCRIPTION
This PR introduces a new commit command that lets users directly commit the generated message as-is, without requiring edits.

While this use case may be rare (especially since we currently only support Ollama and most users run smaller models), it’s useful for the occasional scenario where the LLM produces an ideal commit message. Even if it’s “1 in 1000,” the option gives users more flexibility and speeds up their workflow when the output is spot-on.