### PR TITLE
Refactor gen / generate command handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Updated documents  (README.md and CONTRIBUTING.md)
+- Rewrote the generation portion for clearer control flow and behavior
 
 ### Fixed
 
 - Fixed blank input crashing the program
 - Fixed empty start argument crashing the program
+- Fixed crashes from invalid uses of `gen`/`generate`
 
 ## [0.1.0] - 2025/10/01
 

--- a/src/commizard/commands.py
+++ b/src/commizard/commands.py
@@ -87,12 +87,13 @@ def generate_message(opts: list[str]) -> None:
 
     prompt = llm_providers.generation_prompt + diff
     stat, res = llm_providers.generate(prompt)
-    llm_providers.gen_message = res
-
-    if stat == 0:
-        output.print_generated(res)
-    else:
+    if stat != 0:
         output.print_error(res)
+        return
+
+    res = output.wrap_text(res, 72)
+    llm_providers.gen_message = res
+    output.print_generated(res)
 
 
 supported_commands = {"commit": handle_commit_req,

--- a/src/commizard/llm_providers.py
+++ b/src/commizard/llm_providers.py
@@ -146,19 +146,25 @@ def unload_model() -> None:
 
 
 # TODO: see issues #11 and #15
-def generate(prompt: str) -> str:
+def generate(prompt: str) -> tuple[int, str]:
     """
     generates a response by prompting the selected_model.
     Args:
         prompt: the prompt to send to the LLM.
     Returns:
-        response from the LLM.
+        a tuple of the return code and the response. The return code is 0 if the
+        response is ok, 1 otherwise. The response is the error message if the
+        request fails and the return code is 1.
     """
     url = "http://localhost:11434/api/generate"
-    payload = {"model": selected_model, "prompt": prompt,
-               "stream": False}
+    payload = {"model": selected_model, "prompt": prompt, "stream": False}
     r = http_request("POST", url, json=payload)
-    return r.response.get("response")
+    if r.is_error():
+        return 1, r.err_message()
+    elif r.return_code == 200:
+        return 0, r.response.get("response")
+    else:
+        return r.return_code, f"Unknown status code: {r.err_message()}"
 
 
 def regenerate(prompt: str) -> None:

--- a/src/commizard/llm_providers.py
+++ b/src/commizard/llm_providers.py
@@ -164,7 +164,7 @@ def generate(prompt: str) -> tuple[int, str]:
     elif r.return_code == 200:
         return 0, r.response.get("response")
     else:
-        return r.return_code, f"Unknown status code: {r.err_message()}"
+        return r.return_code, f"Unknown status code: {r.return_code}"
 
 
 def regenerate(prompt: str) -> None:

--- a/src/commizard/llm_providers.py
+++ b/src/commizard/llm_providers.py
@@ -1,6 +1,5 @@
 import requests
 
-from . import git_utils
 from . import output
 
 available_models = None
@@ -147,25 +146,19 @@ def unload_model() -> None:
 
 
 # TODO: see issues #11 and #15
-def generate() -> None:
+def generate(prompt: str) -> str:
     """
-    generate commit message
+    generates a response by prompting the selected_model.
+    Args:
+        prompt: the prompt to send to the LLM.
+    Returns:
+        response from the LLM.
     """
     url = "http://localhost:11434/api/generate"
-    diff = git_utils.get_clean_diff()
-    if diff == "":
-        output.print_warning("No changes to the repository.")
-        return
-    payload = {"model": selected_model, "prompt": generation_prompt + diff,
+    payload = {"model": selected_model, "prompt": prompt,
                "stream": False}
     r = http_request("POST", url, json=payload)
-
-    r = output.wrap_text(r.response.get("response").strip(), 72)
-
-    global gen_message
-    gen_message = r
-
-    output.print_generated(r)
+    return r.response.get("response")
 
 
 def regenerate(prompt: str) -> None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,7 +17,7 @@ from commizard import commands, llm_providers
 )
 @patch("commizard.commands.output.print_warning")
 @patch("commizard.commands.output.print_success")
-@patch("commizard.commands.commit")
+@patch("commizard.commands.git_utils.commit")
 def test_handle_commit_req(mock_commit, mock_print_success, mock_print_warning,
                            gen_message, commit_ret, expected_func, expected_arg,
                            monkeypatch):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -124,19 +124,52 @@ def test_print_available_models(mock_init, mock_print, available_models, opts,
         mock_print.assert_any_call(model)
 
 
-@pytest.mark.parametrize(
-    "opts",
-    [
-        [],
-        ["--dry-run"],
-        ["--foo", "--bar"],
-    ]
-)
-@patch("commizard.llm_providers.generate")
-def test_generate_message(mock_generate, opts):
-    commands.generate_message(opts)
+@patch("commizard.commands.output.print_warning")
+@patch("commizard.commands.git_utils.get_clean_diff")
+def test_generate_message_no_diff(mock_diff, mock_output, monkeypatch):
+    mock_diff.return_value = ""
+    monkeypatch.setattr(commands.llm_providers, "gen_message", None)
 
-    mock_generate.assert_called_once_with()
+    commands.generate_message(["--dummy"])
+
+    mock_output.assert_called_once_with("No changes to the repository.")
+    assert commands.llm_providers.gen_message is None
+
+
+@patch("commizard.commands.output.print_error")
+@patch("commizard.commands.git_utils.get_clean_diff")
+@patch("commizard.commands.llm_providers.generate")
+def test_generate_message_err(mock_gen, mock_diff, mock_output, monkeypatch):
+    mock_diff.return_value = "some diff"
+    mock_gen.return_value = (1, "Error happened")
+    monkeypatch.setattr(commands.llm_providers, "generation_prompt", "PROMPT:")
+    monkeypatch.setattr(commands.llm_providers, "gen_message", None)
+
+    commands.generate_message(["--dummy"])
+
+    mock_gen.assert_called_once_with("PROMPT:some diff")
+    mock_output.assert_called_once_with("Error happened")
+    assert commands.llm_providers.gen_message is None
+
+
+@patch("commizard.commands.output.wrap_text")
+@patch("commizard.commands.output.print_generated")
+@patch("commizard.commands.git_utils.get_clean_diff")
+@patch("commizard.commands.llm_providers.generate")
+def test_generate_message_success(mock_gen, mock_diff, mock_output, mock_wrap,
+                                  monkeypatch):
+    mock_diff.return_value = "some diff"
+    mock_gen.return_value = (0, "The generated commit message")
+    monkeypatch.setattr(commands.llm_providers, "generation_prompt", "PROMPT:")
+    monkeypatch.setattr(commands.llm_providers, "gen_message", None)
+    mock_wrap.side_effect = lambda text, width: f"WRAPPED({text})"
+
+    commands.generate_message(["--dummy"])
+
+    mock_gen.assert_called_once_with("PROMPT:some diff")
+    mock_wrap.assert_called_once_with("The generated commit message", 72)
+    mock_output.assert_called_once_with("WRAPPED(The generated commit message)")
+    assert llm_providers.gen_message == "WRAPPED(The generated commit message)"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -220,22 +220,17 @@ def test_unload_model(mock_http_request, monkeypatch):
 @patch("commizard.llm_providers.http_request")
 def test_generate(mock_http_request, is_error, return_code, response_dict,
                   err_msg, expected, monkeypatch):
-    # Use MagicMock to mock the HttpResponse object
     fake_response = MagicMock()
     fake_response.is_error.return_value = is_error
     fake_response.return_code = return_code
     fake_response.response = response_dict
     fake_response.err_message.return_value = err_msg
-
     mock_http_request.return_value = fake_response
 
-    # patch global selected_model
     monkeypatch.setattr(llm, "selected_model", "mymodel")
 
-    # act
     result = llm.generate("Test prompt")
 
-    # assert
     mock_http_request.assert_called_once_with(
         "POST",
         "http://localhost:11434/api/generate",


### PR DESCRIPTION
The previous approach had grown a bit unwieldy, so I rewrote the flow to make it cleaner, easier to maintain, and more consistent with the rest of the codebase.

- Reorganized command handling logic for gen and generate.
- Simplified control flow to improve readability.
- Ensured existing functionality and behavior remain intact.
- Rewrote tests too.

this also fixes crashes from invalid `gen` requests. Now the program wont crash. There's a problem though: The errors are super generic, and don't give good context. We should make the errors better in the future.