### PR TITLE
Fixing the 3.9 compatibility issues

### DIFF
--- a/src/commizard/cli.py
+++ b/src/commizard/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import concurrent.futures
 import sys
 

--- a/src/commizard/commands.py
+++ b/src/commizard/commands.py
@@ -1,15 +1,19 @@
+from __future__ import annotations
+
 import os
 import platform
 import sys
-from collections.abc import Callable
-from typing import List
+from typing import TYPE_CHECKING
 
 import pyperclip
 
 from . import git_utils, llm_providers, output
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
-def handle_commit_req(opts: List[str]) -> None:
+
+def handle_commit_req(opts: list[str]) -> None:
     """
     commits the generated prompt. prints an error message if commiting fails
     """
@@ -24,7 +28,7 @@ def handle_commit_req(opts: List[str]) -> None:
 
 
 # TODO: implement
-def print_help(opts: List[str]) -> None:
+def print_help(opts: list[str]) -> None:
     """
     prints a list of all commands and a brief description
 
@@ -36,7 +40,7 @@ def print_help(opts: List[str]) -> None:
     """
 
 
-def copy_command(opts: List[str]) -> None:
+def copy_command(opts: list[str]) -> None:
     """
     copies the generated prompt to clipboard according to options passed.
 
@@ -53,7 +57,7 @@ def copy_command(opts: List[str]) -> None:
     output.print_success("Copied to clipboard.")
 
 
-def start_model(opts: List[str]) -> None:
+def start_model(opts: list[str]) -> None:
     """
     Get the model (either local or online) ready for generation based on the
     options passed.
@@ -77,7 +81,7 @@ def start_model(opts: List[str]) -> None:
     llm_providers.select_model(model_name)
 
 
-def print_available_models(opts: List[str]) -> None:
+def print_available_models(opts: list[str]) -> None:
     """
     prints the available models according to options passed.
     """
@@ -94,7 +98,7 @@ def print_available_models(opts: List[str]) -> None:
         print(model)
 
 
-def generate_message(opts: List[str]) -> None:
+def generate_message(opts: list[str]) -> None:
     diff = git_utils.get_clean_diff()
     if diff == "":
         output.print_warning("No changes to the repository.")
@@ -111,7 +115,7 @@ def generate_message(opts: List[str]) -> None:
     output.print_generated(wrapped_res)
 
 
-def cmd_clear(opts: List[str]) -> None:
+def cmd_clear(opts: list[str]) -> None:
     """
     Clear terminal screen (Windows/macOS/Linux).
     """
@@ -122,7 +126,7 @@ def cmd_clear(opts: List[str]) -> None:
         sys.stdout.flush()
 
 
-supported_commands: dict[str, Callable[[List[str]], None]] = {
+supported_commands: dict[str, Callable[[list[str]], None]] = {
     "commit": handle_commit_req,
     "help": print_help,
     "cp": copy_command,

--- a/src/commizard/git_utils.py
+++ b/src/commizard/git_utils.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import subprocess
 
 
-def run_git_command(args: List[str]) -> subprocess.CompletedProcess:
+def run_git_command(args: list[str]) -> subprocess.CompletedProcess:
     """
     Run a git command with the given args.
 
@@ -32,7 +34,7 @@ def is_changed() -> bool:
     return (out.returncode == 0) and (out.stdout.strip() != "")
 
 
-def get_diff() -> Optional[str]:
+def get_diff() -> str | None:
     """
     Get the diff from the current working directory.
 
@@ -49,7 +51,7 @@ def get_diff() -> Optional[str]:
     return None
 
 
-def commit(msg: str) -> Tuple[int, str]:
+def commit(msg: str) -> tuple[int, str]:
     """
     commit with msg as the commit text.
     Returns:
@@ -60,7 +62,7 @@ def commit(msg: str) -> Tuple[int, str]:
     return out.returncode, ret
 
 
-def clean_diff(diff: Optional[str]) -> str:
+def clean_diff(diff: str | None) -> str:
     """
     Remove unnecessary information from the diff.
     """

--- a/src/commizard/llm_providers.py
+++ b/src/commizard/llm_providers.py
@@ -1,12 +1,12 @@
-from typing import Dict, List, Optional, Tuple
+from __future__ import annotations
 
 import requests
 
 from . import output
 
-available_models: Optional[List[str]] = None
-selected_model: Optional[str] = None
-gen_message: Optional[str] = None
+available_models: list[str] | None = None
+selected_model: str | None = None
+gen_message: str | None = None
 
 # Ironically enough, I've used Chat-GPT to write a prompt to prompt other
 # Models (or even itself in the future!)
@@ -90,7 +90,7 @@ def init_model_list() -> None:
 
 
 # TODO: see issue #10
-def list_locals() -> Optional[List[str]]:
+def list_locals() -> list[str] | None:
     """
     return a list of available local AI models
     """
@@ -113,7 +113,7 @@ def select_model(select_str: str) -> None:
         output.print_success(f"{selected_model} loaded.")
 
 
-def load_model(model_name: str) -> Dict:
+def load_model(model_name: str) -> dict:
     """
     Load the local model into RAM
     Args:
@@ -151,7 +151,7 @@ def unload_model() -> None:
 
 
 # TODO: see issues #11 and #15
-def generate(prompt: str) -> Tuple[int, str]:
+def generate(prompt: str) -> tuple[int, str]:
     """
     generates a response by prompting the selected_model.
     Args:

--- a/src/commizard/output.py
+++ b/src/commizard/output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import textwrap
 
 from rich.console import Console

--- a/src/commizard/start.py
+++ b/src/commizard/start.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 
 from rich.color import Color


### PR DESCRIPTION
Fixes #67 

Used `from __future import annotations` to fix the linting and testing issues for python 3.9 test hint issues

Most of the changes were done via `ruff`.

Look into the e2e tests and CI checks here : [e2e test](https://github.com/bored-arvi/CommiZard/actions/runs/18630881130) and [CI check](https://github.com/bored-arvi/CommiZard/actions/runs/18630867035)