### PR TITLE
Standardizing CLI codes

### DIFF
--- a/src/commizard/cli.py
+++ b/src/commizard/cli.py
@@ -23,7 +23,7 @@ def handle_args():
         return
     if sys.argv[1] in ("-v", "--version"):
         print(f"CommiZard {version}")
-        sys.exit(0)  # This is fine - it's before main() really starts
+        sys.exit(0)
     elif sys.argv[1] in ("-h", "--help"):
         print(help_msg.strip(), end="\n")
         sys.exit(0)


### PR DESCRIPTION
### Fixes  #62 

---

### Summary of Changes

* Converted `main()` to return an `int` exit code instead of `None`, aligning with Python CLI conventions and `pytest` expectations.
* Added explicit `sys.exit(0)` for `--help` and `--version` options to ensure immediate termination before startup.
* Replaced bare `return` statements with explicit exit codes (`return 1` for errors, `return 0` for success).
* Wrapped main loop with a `try` block to gracefully handle `EOFError` and `KeyboardInterrupt`.
* Improved clarity and compliance with linting/formatting via Ruff.

**Rationale**

* The change ensures consistent and predictable process termination behavior.
* Facilitates testing (`pytest`) by returning deterministic codes.
* Improves maintainability and aligns with Python packaging tools that expect CLI entry points to return numeric exit codes.

All [checks](https://github.com/bored-arvi/CommiZard/actions/runs/18651660972) were passed successfully

This also adheres to the request made by @Chungzter as follows

> Also, let's not touch the internal possible errors and just stick to the main workflow and exits inside of main() for now.

### Addition screenshot of the script run to verify the exit codes 
<img width="632" height="923" alt="image" src="https://github.com/user-attachments/assets/95ce98df-7961-4855-a98c-92ae981b6320" />

# Additonal possible improvement 
Adding this script as a seperate issue to the `master` repo. (find the `.sh` code [here](https://github.com/bored-arvi/CommiZard/blob/script/return_codes.sh))
