### PR TITLE
Use trusted publishing to publish the software to PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -53,5 +53,3 @@ jobs:
 
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
We now get rid of the token way to do this in a more modern way, without the need of relying on the API TOKEN or any other api token: Now the settings in the pypi website verify where this package is coming. This will make things more clear and potentially safer by **minimizing the attack surface**.