### PR TITLE
Refactor request calls

### DIFF
--- a/src/commizard/llm_providers.py
+++ b/src/commizard/llm_providers.py
@@ -54,7 +54,7 @@ def http_request(method: str, url: str, **kwargs) -> HttpResponse:
     method = method.upper()  # All methods are upper case
     try:
         if method in ("GET", "POST", "PUT", "PATCH", "DELETE"):
-            r = requests.request(method, url, **kwargs) # noqa: S113
+            r = requests.request(method, url, **kwargs)  # noqa: S113
         else:
             raise ValueError(f"{method} is not a valid method.")
         try:


### PR DESCRIPTION
Previously, we used a redundant control flow for selecting the wrappers, but with the new refactored version, all is condensed into a simple if/else block.

Also increased the read timeout for loading models to RAM, because the bigger ones take some time (right now it's 10 minutes. We'll see if people need more, but I don't think people do).