### PR TITLE
Refactor stream printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Improved startup time by lazy importing modules
 
+### Fixed
+
+- The printing width of the streaming output now correctly changes for the body
+  of the commit message
+
 ## [0.4.3] - 2026-02-05
 
 ### Changed

--- a/src/commizard/llm_providers.py
+++ b/src/commizard/llm_providers.py
@@ -357,6 +357,8 @@ def stream_generate(prompt: str) -> tuple[int, str]:
             ),
         ):
             output.console.width = 50
+            new_paragraph = False
+            prev_char = ""  # in case double newline was in two separate chunks
             for raw in stream:
                 line = raw.strip()
 
@@ -373,6 +375,13 @@ def stream_generate(prompt: str) -> tuple[int, str]:
                 if not delta:
                     continue
                 delta = delta.get("content", "")
+
+                if not new_paragraph:
+                    if "\n\n" in (prev_char + delta):
+                        output.console.width = 72
+                        new_paragraph = True
+                    prev_char = delta[-1:]  # only need last char
+
                 stream_txt.append(delta)
 
     except (KeyError, IndexError):

--- a/src/commizard/output.py
+++ b/src/commizard/output.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 from rich.console import Console
-from rich.live import Live
-from rich.text import Text
 
 console: Console = Console()
 error_console: Console = Console(stderr=True)
-stream_console: Console = Console(width=70)
-stream_txt = Text(style="blue")
 
 
 def init_console(color: bool) -> None:
@@ -17,12 +13,11 @@ def init_console(color: bool) -> None:
     Args:
         color (bool): Whether to use color.
     """
-    global console, error_console, stream_console
+    global console, error_console
     if color:
         error_console = Console(stderr=True, style="bold red")
     else:
         console = Console(color_system=None)
-        stream_console = Console(color_system=None, width=70)
         error_console = Console(stderr=True, color_system=None)
 
 
@@ -93,22 +88,3 @@ def wrap_text(text: str, width: int = 70) -> str:
     ]
     # preserve the last \n if the texts contains it.
     return "\n".join(wrapped_lines) + ("\n" if text.endswith("\n") else "")
-
-
-# TODO: Streaming wrap currently handled by Rich Live. This should be replaced
-#       with a stream wrapper for a more efficient execution
-def live_stream() -> Live:
-    return Live(
-        stream_txt,
-        console=stream_console,
-        vertical_overflow="visible",
-        refresh_per_second=30,
-    )
-
-
-def set_stream_print_width(width: int) -> None:
-    stream_console.width = width
-
-
-def print_token(tok: str) -> None:
-    stream_txt.append(tok)

--- a/tests/unit/test_llm_providers.py
+++ b/tests/unit/test_llm_providers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import requests
@@ -321,7 +321,7 @@ def test_stream_request_dunder_iter(error: tuple[bool, str]):
         ),
         # http_request succeeds but no models
         (False, {"models": []}, []),
-        # Bizzare case where There isn't any error but response is None
+        # Bizarre case where There isn't any error but response is None
         (False, None, None),
     ],
 )
@@ -584,15 +584,11 @@ def test_get_error_message(error_code, expected_result):
         ),
     ],
 )
-@patch("commizard.llm_providers.output.print_token")
-@patch("commizard.llm_providers.output.set_stream_print_width")
-@patch("commizard.llm_providers.output.live_stream")
+@patch("rich.live.Live")
 @patch("commizard.llm_providers.StreamRequest")
 def test_stream_generate_no_error(
     mock_stream_request,
     mock_live_stream,
-    mock_set_stream_print_width,
-    mock_print_token,
     sse_events,
     expected_results,
     monkeypatch,
@@ -607,9 +603,6 @@ def test_stream_generate_no_error(
     res = llm.stream_generate("testing")
     mock_stream_request.assert_called_once()
     mock_live_stream.assert_called_once()
-    mock_set_stream_print_width.assert_called_once_with(70)
-    expected_calls = [call(i) for i in expected_results]
-    mock_print_token.assert_has_calls(expected_calls)
     assert res == (0, "".join(expected_results))
 
 
@@ -637,14 +630,12 @@ def test_stream_generate_no_error(
         ),
     ],
 )
-@patch("commizard.llm_providers.output.print_token")
-@patch("commizard.llm_providers.output.set_stream_print_width")
-@patch("commizard.llm_providers.output.live_stream")
+@patch("rich.text.Text.append")
+@patch("rich.live.Live")
 @patch("commizard.llm_providers.StreamRequest")
 def test_stream_generate_bad_response(
     mock_stream_request,
     mock_live_stream,
-    mock_set_stream_print_width,
     mock_print_token,
     sse_event,
     expected_return,
@@ -659,7 +650,6 @@ def test_stream_generate_bad_response(
     res = llm.stream_generate("testing")
     mock_stream_request.assert_called_once()
     mock_live_stream.assert_called_once()
-    mock_set_stream_print_width.assert_called_once_with(70)
     mock_print_token.assert_not_called()
     assert res == expected_return
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -108,29 +108,3 @@ def test_print_table(mock_print, cols, rows, title):
 def test_wrap_text(text, width, expected):
     result = output.wrap_text(text, width=width)
     assert result == expected
-
-
-@patch("commizard.output.Live")
-def test_live_stream(mock_live):
-    res = output.live_stream()
-    mock_live.assert_called_once_with(
-        output.stream_txt,
-        console=output.stream_console,
-        vertical_overflow="visible",
-        refresh_per_second=30,
-    )
-    assert isinstance(res, type(output.Live()))
-
-
-def test_set_stream_print_width(monkeypatch):
-    monkeypatch.setattr(output.stream_console, "width", 69420)
-    assert output.stream_console.width == 69420
-    output.set_stream_print_width(42)
-    assert output.stream_console.width == 42
-
-
-@patch.object(output, "stream_txt")
-def test_print_token(mock_stream_txt):
-    tok = "hello"
-    output.print_token(tok)
-    mock_stream_txt.append.assert_called_once_with(tok)


### PR DESCRIPTION
After a long and semi-successful attempt at a stream wrapper (see [this comment](https://github.com/Chungzter/CommiZard/issues/143#issuecomment-3898637583)) it looks like the soft wrap + hard wrap at the end approach we had was orders of magnitude faster than that implementation, since the code was very inefficient.

This made me realize that the best approach is to probably just keep using the rich library's capabilities to it's full potential. Now the code is more refined, faster, and lighter.

There was also the issue of changing the width of the printing response for the body, which is now correctly done. Keep in mind that the string resulting from the `cp` command still behaves the same, and this is merely a visual fix.